### PR TITLE
Bunching local updates

### DIFF
--- a/RMLMapper/README.md
+++ b/RMLMapper/README.md
@@ -20,6 +20,8 @@ A node.js server instance which connects to the the MQTT broker and converts the
   - 3 options for Solid identity providers are included, but this can be set to any valid address.
   - `LOCATION` defines the default location where the IoT gets saved to on the Pod.
     If there's already a file present at another location, this gets discovered automatically.
+  - `UPDATER_DELAY_MS` defines the amount of time that has to be waited between updating the pod store with the local one.
+    This is done to avoid sending too many fetch requests to the Solid server and thereby overloading it.
 
 - Create a `credentials.mjs` file in the `src` folder and add the following code:
 

--- a/RMLMapper/src/config.mjs
+++ b/RMLMapper/src/config.mjs
@@ -151,3 +151,4 @@ export const IDENTITY_PROVIDER = 'https://solidweb.org';
 export const USERNAME = username;
 export const PASSWORD = password;
 export const LOCATION = 'private/iot/iot_data.ttl'
+export const UPDATER_DELAY_MS = 30e3;


### PR DESCRIPTION
Code was adapted to bunch incoming messages into a local rdf graph and sending update requests to the database on the Solid server only sporadically.
This is done to avoid sending too many fetch requests to the Solid server thereby overloading it, since the previous update could not yet be processed before the new one is requested.